### PR TITLE
fix: macos machine images

### DIFF
--- a/images/macos/scripts/helpers/Common.Helpers.psm1
+++ b/images/macos/scripts/helpers/Common.Helpers.psm1
@@ -105,7 +105,11 @@ function Invoke-DownloadWithRetry {
 }
 
 function isVeertu {
-    return (Test-Path -Path "/Library/Application Support/Veertu" -or Test-Path -Path "/Library/Application Support/Tart")
+    # Uncomment this line if using Veertu
+    # return (Test-Path -Path "/Library/Application Support/Veertu")
+    #
+    # For tart we'll just check the tart folder
+    return (Test-Path -Path "/Library/Application Support/Tart")
 }
 
 function Get-Architecture {

--- a/images/macos/templates/macOS-13.arm64.tart.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.tart.pkr.hcl
@@ -56,11 +56,16 @@ variable "xcode_install_sas" {
   default = ""
 }
 
+variable "disk_size_gb" {
+  type = number
+  default = 200
+}
+
 source "tart-cli" "tart" {
   vm_name      = "${var.vm_name}"
   cpu_count    = var.vcpu_count
   memory_gb    = var.ram_size
-  disk_size_gb = 200
+  disk_size_gb = var.disk_size_gb
   headless     = true
   ssh_password = var.vm_password
   ssh_username = var.vm_username

--- a/images/macos/templates/macOS-13.arm64.tart.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.tart.pkr.hcl
@@ -190,6 +190,7 @@ build {
       "${path.root}/../scripts/build/install-powershell.sh",
       "${path.root}/../scripts/build/install-mono.sh",
       "${path.root}/../scripts/build/install-dotnet.sh",
+      "${path.root}/../scripts/build/install-python.sh",
       "${path.root}/../scripts/build/install-azcopy.sh",
       "${path.root}/../scripts/build/install-openssl.sh",
       "${path.root}/../scripts/build/install-ruby.sh",

--- a/images/macos/templates/macOS-14.arm64.tart.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.tart.pkr.hcl
@@ -56,11 +56,16 @@ variable "xcode_install_sas" {
   default = ""
 }
 
+variable "disk_size_gb" {
+  type = number
+  default = 200
+}
+
 source "tart-cli" "tart" {
   vm_name      = "${var.vm_name}"
   cpu_count    = var.vcpu_count
   memory_gb    = var.ram_size
-  disk_size_gb = 200
+  disk_size_gb = var.disk_size_gb
   headless     = true
   ssh_password = var.vm_password
   ssh_username = var.vm_username

--- a/images/macos/templates/macOS-14.arm64.tart.pkr.hcl
+++ b/images/macos/templates/macOS-14.arm64.tart.pkr.hcl
@@ -185,6 +185,7 @@ build {
       "${path.root}/../scripts/build/install-powershell.sh",
       "${path.root}/../scripts/build/install-mono.sh",
       "${path.root}/../scripts/build/install-dotnet.sh",
+      "${path.root}/../scripts/build/install-python.sh",
       "${path.root}/../scripts/build/install-azcopy.sh",
       "${path.root}/../scripts/build/install-openssl.sh",
       "${path.root}/../scripts/build/install-ruby.sh",

--- a/images/macos/templates/warpbuild.pkr.hcl
+++ b/images/macos/templates/warpbuild.pkr.hcl
@@ -38,11 +38,16 @@ variable "image_os" {
   default = "macos14"
 }
 
+variable "disk_size_gb" {
+  type = number
+  default = 200
+}
+
 source "tart-cli" "tart" {
   vm_name      = "${var.vm_name}"
   cpu_count    = var.vcpu_count
   memory_gb    = var.ram_size
-  disk_size_gb = 200
+  disk_size_gb = var.disk_size_gb
   headless     = true
   ssh_password = var.vm_password
   ssh_username = var.vm_username

--- a/images/macos/variables/macos-13.arm64.tart.pkrvars.hcl
+++ b/images/macos/variables/macos-13.arm64.tart.pkrvars.hcl
@@ -4,3 +4,4 @@ xcode_install_storage_url = ""
 xcode_install_sas = ""
 vm_username = "runner"
 vm_password = "admin"
+disk_size_gb = 200

--- a/images/macos/variables/macos-14.arm64.tart.pkrvars.hcl
+++ b/images/macos/variables/macos-14.arm64.tart.pkrvars.hcl
@@ -4,4 +4,4 @@ xcode_install_storage_url = ""
 xcode_install_sas = ""
 vm_username = "runner"
 vm_password = "admin"
-disk_size_gb = 200
+disk_size_gb = 250

--- a/images/macos/variables/macos-14.arm64.tart.pkrvars.hcl
+++ b/images/macos/variables/macos-14.arm64.tart.pkrvars.hcl
@@ -4,3 +4,4 @@ xcode_install_storage_url = ""
 xcode_install_sas = ""
 vm_username = "runner"
 vm_password = "admin"
+disk_size_gb = 200

--- a/scripts/macos/macOS.arm64.tart.push.sh
+++ b/scripts/macos/macOS.arm64.tart.push.sh
@@ -66,7 +66,7 @@ if [ "$warp_env" == "warpbuild-1" ]; then
   rm ~/.docker/config.json
   mv ~/.docker/config.json.bak ~/.docker/config.json
 
-end
+fi
 
 # Check if warp_env is not warpbuild-prod
 if [ "$warp_env" != "warpbuild-prod" ]; then


### PR DESCRIPTION
## Desc

Fixes a bunch of issues with macos-13 and 14 images. Including -
- Out of storage issue because of hard coded minimal disk size which was expanded later on. This should have happened earlier.
- `isVeertu` func failing.
- `pipx` not being installed
- Push script expecting preprod variables when pushing to prod.